### PR TITLE
Update ZVHH SOT Calc

### DIFF
--- a/CREATE_2010_TABLE.sql
+++ b/CREATE_2010_TABLE.sql
@@ -14,17 +14,21 @@ SELECT
 		WHEN dec22upd.B11004_001E > 0 
 			THEN ((dec22upd.B11004_010E + dec22upd.B11004_016E)/dec22upd.B11004_001E) 
 		ELSE -9999 
-		END AS 'SPFAM_SOT', 
+	END AS 'SPFAM_SOT', 
 	acs14s.POP_LEP,
 	acs14s.POP_LEP_SOT,
-	acs14s.POP_ZVHHS,
-	acs14s.POP_ZVHHS_SOT,
+	ZVHH.B25044_001E as TotalHHs_ACS2014,
+	CASE 
+		WHEN ZVHH.B25044_001E > 0 
+			THEN (ZVHH.B25044_003E + ZVHH.B25044_010E) / CAST(ZVHH.B25044_001E AS DECIMAL(10,2)) --TOTAL ZERO-VEHICLE HOUSEHOLDS / TOTAL HOUSEHOLDS
+		ELSE -9999                                                                               --CAST one of the integers as decimal BEFORE doing division, get a decimal result :) 
+	END as POP_ZVHHS_SOT, 
 	acs14s.POP_HUS_RENT50,
 	CASE 
 		WHEN dec22upd.B25070_001E > 0 
 			THEN (acs14s.POP_HUS_RENT50/dec22upd.B25070_001E) 
 		ELSE -9999 
-		END AS 'POP_HUS_RENT50_SOT', 
+	END AS 'POP_HUS_RENT50_SOT', 
 	acs14cn00.Asian_Pacific_Islander_2014,
 	acs14cn00.Black_Alone_2014,
 	acs14cn00.Hispanic_Alone_2014,
@@ -40,3 +44,5 @@ INNER JOIN
 	EJ_2016.ACS_2014_ALL_COC_DATA_TRACTS AS coc ON dl.GEOID = coc.GEOID
 LEFT JOIN
 	EJ_2016.update_2014_acs_dec22 AS dec22upd ON coc.GEOID = CONCAT (dec22upd.state, dec22upd.county, dec22upd.tract)
+LEFT JOIN 
+	EJ_2016.ACS5_2014_ZEROVEHICLEHHS as ZVHH ON acs14cn00.GEOID = ZVHH.GEOID


### PR DESCRIPTION
@Keareys or @tombuckley could you review these changes when you get the chance? 

Updated ZVHH Sot Calculation
- Performed left join to access zero-vehicle household figures as well as total household figures. 
- Used cast to decimal for denominator when calculating zero-vehicle household share of total as result will be decimal if you convert before division. 
- Divided by total households instead of by total population.