### PR TITLE
Update ZVHH SOT Calculations (ACS 2014)

### DIFF
--- a/CREATE_2010_TABLE.sql
+++ b/CREATE_2010_TABLE.sql
@@ -1,4 +1,4 @@
-CREATE VIEW EJ_2016.year_2010_tract_data AS
+CREATE VIEW [EJ_2016].[year_2010_tract_data] AS 
 SELECT 
 	acs14s.GEOID,
 	acs14s.TotalPopulation,
@@ -13,18 +13,22 @@ SELECT
 	CASE 
 		WHEN dec22upd.B11004_001E > 0 
 			THEN ((dec22upd.B11004_010E + dec22upd.B11004_016E)/dec22upd.B11004_001E) 
-		ELSE -9999 
-		END AS 'SPFAM_SOT', 
+		ELSE NULL 
+	END AS 'SPFAM_SOT', 
 	acs14s.POP_LEP,
 	acs14s.POP_LEP_SOT,
-	acs14s.POP_ZVHHS,
-	acs14s.POP_ZVHHS_SOT,
+	ZVHH.B25044_001E as TotalHHs_ACS2014,
+	CASE 
+		WHEN ZVHH.B25044_001E > 0 
+			THEN (ZVHH.B25044_003E + ZVHH.B25044_010E) / CAST(ZVHH.B25044_001E AS DECIMAL(10,2)) --TOTAL ZERO-VEHICLE HOUSEHOLDS / TOTAL HOUSEHOLDS
+		ELSE NULL                                                                               --CAST one of the integers as decimal BEFORE doing division, get a decimal result :) 
+	END as POP_ZVHHS_SOT, 
 	acs14s.POP_HUS_RENT50,
 	CASE 
 		WHEN dec22upd.B25070_001E > 0 
 			THEN (acs14s.POP_HUS_RENT50/dec22upd.B25070_001E) 
-		ELSE -9999 
-		END AS 'POP_HUS_RENT50_SOT', 
+		ELSE NULL 
+	END AS 'POP_HUS_RENT50_SOT', 
 	acs14cn00.Asian_Pacific_Islander_2014,
 	acs14cn00.Black_Alone_2014,
 	acs14cn00.Hispanic_Alone_2014,
@@ -40,3 +44,5 @@ INNER JOIN
 	EJ_2016.ACS_2014_ALL_COC_DATA_TRACTS AS coc ON dl.GEOID = coc.GEOID
 LEFT JOIN
 	EJ_2016.update_2014_acs_dec22 AS dec22upd ON coc.GEOID = CONCAT (dec22upd.state, dec22upd.county, dec22upd.tract)
+LEFT JOIN 
+	EJ_2016.ACS5_2014_ZEROVEHICLEHHS as ZVHH ON acs14cn00.GEOID = ZVHH.GEOID


### PR DESCRIPTION
@Keareys and @tombuckley could you take a look at these changes when you get a moment?
Updated ZVHH SOT Calcs
- Updated calculation to divide zero-vehicle households by total households instead of by total population
- Used case to handle zero-denominator cases
- Set zero-denominator cases to null instead of -9999 as -9999 will cause issues with data classification 
- Set cases where zero denominator to null instead of -9999 as that creates issue with data classification
- joined with updated zero-vehicle household variables to use data from most recent zerovehicle hh table pulled from the census
- Updated case statement spacing for readability